### PR TITLE
MAINT: remove %matplotlib inline and contents directive

### DIFF
--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # The Aiyagari Model
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/arellano.md
+++ b/lectures/arellano.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Default Risk and Income Fluctuations
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} python
@@ -80,7 +76,6 @@ import numpy as np
 import quantecon as qe
 
 from numba import njit, prange
-%matplotlib inline
 ```
 
 ## Structure

--- a/lectures/cass_koopmans_1.md
+++ b/lectures/cass_koopmans_1.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Cass-Koopmans Model
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture and {doc}`Cass-Koopmans Competitive Equilibrium <cass_koopmans_2>` describe a model that Tjalling Koopmans {cite}`Koopmans`

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Cass-Koopmans Competitive Equilibrium
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture continues our analysis in this  lecture

--- a/lectures/coase.md
+++ b/lectures/coase.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Coase's Theory of the Firm <single: Coase's Theory of the Firm>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -60,7 +56,6 @@ We'll use the following imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.optimize import fminbound
 from interpolation import interp
 ```

--- a/lectures/knowing_forecasts_of_others.md
+++ b/lectures/knowing_forecasts_of_others.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Knowing the Forecasts of Others
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Markov Perfect Equilibrium
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/matsuyama.md
+++ b/lectures/matsuyama.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Globalization and Cycles
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture, we review the paper [Globalization and Synchronization of Innovation Cycles](http://www.centreformacroeconomics.ac.uk/Discussion-Papers/2015/CFMDP2015-27-Paper.pdf) by [Kiminori Matsuyama](http://faculty.wcas.northwestern.edu/~kmatsu/), [Laura Gardini](http://www.mdef.it/index.php?id=32) and [Iryna Sushko](http://irynasushko.altervista.org/).
@@ -45,7 +41,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from numba import jit
 from ipywidgets import interact
 ```

--- a/lectures/matsuyama.md
+++ b/lectures/matsuyama.md
@@ -22,7 +22,7 @@ kernelspec:
 
 ## Overview
 
-In this lecture, we review the paper [Globalization and Synchronization of Innovation Cycles](http://www.centreformacroeconomics.ac.uk/Discussion-Papers/2015/CFMDP2015-27-Paper.pdf) by [Kiminori Matsuyama](http://faculty.wcas.northwestern.edu/~kmatsu/), [Laura Gardini](http://www.mdef.it/index.php?id=32) and [Iryna Sushko](http://irynasushko.altervista.org/).
+In this lecture, we review the paper [Globalization and Synchronization of Innovation Cycles](http://www.centreformacroeconomics.ac.uk/Discussion-Papers/2015/CFMDP2015-27-Paper.pdf) by [Kiminori Matsuyama](http://faculty.wcas.northwestern.edu/~kmatsu/), [Laura Gardini](https://en.wikipedia.org/wiki/Laura_Gardini) and [Iryna Sushko](http://irynasushko.altervista.org/).
 
 This model helps us understand several interesting stylized facts about the world economy.
 

--- a/lectures/rational_expectations.md
+++ b/lectures/rational_expectations.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Rational Expectations Equilibrium <single: Rational Expectations Equilibrium>`
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "If you're so smart, why aren't you rich?"
 ```

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Stability in Linear Rational Expectations Models
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture deploys the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment

--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Uncertainty Traps
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture, we study a simplified version of an uncertainty traps model of Fajgelbaum, Schaal and Taschereau-Dumouchel {cite}`fun`.


### PR DESCRIPTION
This PR addresses https://github.com/QuantEcon/meta/issues/134 and removes `contents` directives to simplify